### PR TITLE
fix for OS X

### DIFF
--- a/petlib/compile.py
+++ b/petlib/compile.py
@@ -35,10 +35,10 @@ else:
     libraries=["crypto"]
     extra_compile_args=['-Wno-deprecated-declarations']
     if platform.system() == "Darwin":
-        include_dirs=['/opt/local/include']
-        # FIXME(ben): not entirely clear to me why I don't seem to
-        # have to include /opt/local/lib.
-        library_dirs=[]
+        include_dirs = ['/usr/local/opt/openssl/include',
+                        '/usr/local/ssl/include']
+        library_dirs=['/usr/local/opt/openssl/lib',
+                      '/usr/local/ssl/lib']
     else:
         include_dirs=[]
         library_dirs=[]


### PR DESCRIPTION
The pull request makes the necessary changes for petlib to be installed on OS X. It assumes that OpenSSL is installed. 

* The most straightforward option is to have OpenSSL installed via Homebrew. At the time of this commit, Homebrew installs OpenSSL 1.0.2j, which works fine with petlib.

* If OpenSSL is installed manually, it is assumed that it has been installed under /usr/local/ssl.

