### PR TITLE
Make `get_tag` return `tag` as `bytes`

### DIFF
--- a/petlib/__init__.py
+++ b/petlib/__init__.py
@@ -1,5 +1,5 @@
 # The petlib version
-VERSION = '0.0.43'
+VERSION = '0.0.44'
 
 
 __all__ = ["bindings", "bn", "cipher", "compile", "ecdsa", "ec", "encode", "hmac", "pack"]
@@ -13,7 +13,7 @@ def run_tests():
     # List all petlib files in the directory
     petlib_dir = os.path.dirname(os.path.realpath(__file__))
     pyfiles = glob.glob(os.path.join(petlib_dir, '*.py'))
-    
+
     # Run the test suite
     print("Directory: %s" % pyfiles)
     res = pytest.main(["-v", "-x"] + pyfiles)


### PR DESCRIPTION
Change return type of the ``tag`` to ``bytes`` in ``cipher.get_tag`` function.

Hope you don't mind the removal of trailing whitespace that my editor did.