### PR TITLE
Returning False in __eq__ if other type differs

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -8,6 +8,7 @@ Tariq Elahi        (https://github.com/TariqEE)
 Panos Louridas     (https://github.com/louridas)
 Bogdan Kulynych    (https://github.com/bogdan-kulynych)
 Wouter Lueks       (https://github.com/wouterl)
+Ravi Rahman        (https://github.com/ravirahman)
 
 FUNDING
 

--- a/petlib/bn.py
+++ b/petlib/bn.py
@@ -293,6 +293,10 @@ class Bn(object):
         return self.__inner_cmp__(other) <= 0
 
     def __eq__(self, other):
+        if isinstance(other, int):
+            other = Bn(other)
+        if not isinstance(other, Bn):
+            return False
         return self.__inner_cmp__(other) == 0
 
     def __ne__(self, other):
@@ -976,6 +980,7 @@ def test_bn_cmp():
     assert Bn(1) <= Bn(2)
     assert Bn(2) <= Bn(2)
     assert Bn(2) == Bn(2)
+    assert not Bn(2) == None
     assert Bn(2) <= Bn(3)
     assert Bn(2) < Bn(3)
 

--- a/petlib/ec.py
+++ b/petlib/ec.py
@@ -181,6 +181,8 @@ class EcGroup(object):
         return res
 
     def __eq__(self, other):
+        if not isinstance(other, EcGroup):
+            return False
         res = _C.EC_GROUP_cmp(self.ecg, other.ecg, get_ctx().bnctx)
         return res == 0
 
@@ -478,8 +480,9 @@ class EcPt(object):
         return self.__eq__(other)
 
     def __eq__(self, other):
+        if not isinstance(other, EcPt):
+            return False
         if __debug__:
-            _check(isinstance(other, EcPt))
             _check(other.group == self.group)
         r = int(
             _C.EC_POINT_cmp(
@@ -571,6 +574,7 @@ def test_ec_list_group():
 
 def test_ec_build_group():
     G = EcGroup(409)
+    assert not G == None
     assert G.nid() == 409
     H = EcGroup(410)
     assert G.check_point(G.generator())
@@ -600,6 +604,7 @@ def test_ec_from_x():
 def test_ec_arithmetic():
     G = EcGroup(713)
     g = G.generator()
+    assert not g == None
     assert g + g == g + g
     assert g + g == g.pt_double()
     assert g + g == Bn(2) * g

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='petlib',
       url=r'https://pypi.python.org/pypi/petlib/',
       packages=['petlib'],
       license="2-clause BSD",
-      long_description="""A library wrapping Open SSL low-level cryptographic libraries to build Privacy Enhancing Technoloies (PETs)""",
+      long_description="""A library wrapping Open SSL low-level cryptographic libraries to build Privacy Enhancing Technologies (PETs)""",
 
       setup_requires=["cffi>=1.0.0",
                       "pytest >= 2.6.4"],


### PR DESCRIPTION
In `__eq__(self, other)` for `Bn`, `EcGroup`, and `EcPt`,
the comparison raised an exception if `other` is not
the proper type. Added short-circuiting logic to
return False (instead of crashing) if the other type
is incorrect. Updated test cases.