### PR TITLE
Replace deprecated clock() method by process_time()

### DIFF
--- a/contrib/ec_timing.py
+++ b/contrib/ec_timing.py
@@ -11,10 +11,10 @@ for gid in curves:
 
     rnd = [G.order().random() for _ in range(100)]
 
-    t0 = time.clock()
+    t0 = time.process_time()
     for r in rnd:
         dud = r * gx
-    t1 = time.clock()
+    t1 = time.process_time()
 
     repreats = 1000
     t = []
@@ -22,10 +22,10 @@ for gid in curves:
         o = Bn(2) ** x
         tests = [o.random() for _ in range(repreats)]
 
-        tx = time.clock()
+        tx = time.process_time()
         for y in tests:
             dud = y * gx
-        t += [time.clock() - tx]
+        t += [time.process_time() - tx]
         # print(x, t[-1] / repreats)
     if abs(t[0] - t[-1]) < 5.0 / 100:
         const = "CONST"

--- a/examples/EcGroup_timing.py
+++ b/examples/EcGroup_timing.py
@@ -18,10 +18,10 @@ if __name__ == "__main__":
             o = Bn(2) ** x
             tests = [o.random() for _ in range(repreats)]
 
-            t0 = time.clock()
+            t0 = time.process_time()
             for y in tests:
                 y * h
-            t += [time.clock() - t0]
+            t += [time.process_time() - t0]
             # print x, t[-1] / repreats
         res = abs(t[0] - t[-1]) < 1.0 / 100
         if res:

--- a/examples/GK15ringsig.py
+++ b/examples/GK15ringsig.py
@@ -9,8 +9,8 @@ import math
 
 ## ######################################################
 ## An implementation of the ring signature scheme in
-## 
-##    Jens Groth and Markulf Kohlweiss. "One-out-of-Many Proofs: 
+##
+##    Jens Groth and Markulf Kohlweiss. "One-out-of-Many Proofs:
 ##    Or How to Leak a Secret and Spend a Coin"
 ##    Cryptology ePrint Archive: Report 2014/764
 ##
@@ -38,7 +38,7 @@ def setup():
 def Com(ck, m, k):
     """ Pedersen Commitment. """
     (G, g, h, o) = ck
-    return m * g + k * h    
+    return m * g + k * h
 
 
 def ProveZeroOne(ck, c, m, r):
@@ -71,8 +71,8 @@ def VerifyZeroOne(ck, c, proof):
 
 
 def ProveOneOfN(ck, cis, el, r, message = ""):
-    """ NIZK Proof that Com(0; r) is within Cis. 
-        The fact that it is the el'th commitmtnet is not revealed. 
+    """ NIZK Proof that Com(0; r) is within Cis.
+        The fact that it is the el'th commitmtnet is not revealed.
         + Ring signature on "message". """
     n = int(math.ceil(math.log(len(cis)) / math.log(2)))
     assert Com(ck, 0, r) == cis[el]
@@ -81,7 +81,7 @@ def ProveOneOfN(ck, cis, el, r, message = ""):
     ## Commit to the bits of the index
     el = Bn(el)
     eli = [Bn(int(el.is_bit_set(i))) for i in range(n)]
-    
+
     ri  = [o.random() for i in range(n)]
     ai  = [o.random() for i in range(n)]
     si  = [o.random() for i in range(n)]
@@ -105,7 +105,7 @@ def ProveOneOfN(ck, cis, el, r, message = ""):
                 p = poly_mul(o, p, [ ai[j] , eli[j] ])
 
         p_idx_i += [p]
-        
+
     # Compute all Cdi's
     roi = []
     cdi = []
@@ -155,7 +155,7 @@ def VerifyOneOfN(ck, cis, proof, message = ""):
         assert 0 <= fi[k] < o
         assert 0 <= zai[k] < o
         assert 0 <= zbi[k] < o
-        
+
         assert G.check_point(Celi[k])
         assert G.check_point(Cai[k])
         assert G.check_point(Cbi[k])
@@ -311,35 +311,35 @@ def notest_timing(upper=101):
     ck = setup()
     (G, g, h, o) = ck
     c0 = Com(ck, 1, o.random())
-    
+
     r = o.random()
     cr = Com(ck,0, r)
 
     import time
 
-     
+
     repeats = 10
 
     all_sizes = range(10, upper, 10)
     prove_time = []
     verify_time = []
     for size in all_sizes:
-        cis = [c0] * (size + 1) + [cr]   
+        cis = [c0] * (size + 1) + [cr]
 
-        t0 = time.clock() 
+        t0 = time.process_time()
         for _ in range(repeats):
             proof = ProveOneOfN(ck, cis, len(cis)-1, r, message="Hello World!")
-        t1 = time.clock()
+        t1 = time.process_time()
 
         dt = (t1-t0) / repeats
         prove_time += [ dt ]
         print( "Proof time: %s - %2.4f" % (size, dt) )
 
-        t0 = time.clock() 
+        t0 = time.process_time()
         for _ in range(repeats):
             ret = VerifyOneOfN(ck, cis, proof, message="Hello World!")
             assert ret
-        t1 = time.clock()
+        t1 = time.process_time()
 
         dt = (t1-t0) / repeats
         verify_time += [ dt ]
@@ -368,7 +368,7 @@ if __name__ == "__main__":
     if args.cprof:
         import cProfile
         cProfile.run("notest_timing(51)", sort="tottime")
-        
+
 
     if args.lprof:
         from line_profiler import LineProfiler
@@ -377,7 +377,7 @@ if __name__ == "__main__":
         profile.run("notest_timing(31)")
         profile.print_stats()
 
-    
+
     if args.plot:
 
         all_sizes, prove_time, verify_time = notest_timing()
@@ -396,7 +396,7 @@ if __name__ == "__main__":
             name='Verification',
         )
         data = Data([trace0, trace1])
-        
+
         layout = Layout(
             title='Timing for GK15 Proof and Verification using petlib',
             xaxis=XAxis(

--- a/examples/amacscreds.py
+++ b/examples/amacscreds.py
@@ -1,5 +1,5 @@
 ## An implementation of the credential scheme based on an algebraic
-## MAC proposed by Chase, Meiklejohn and Zaverucha in Algebraic MACs and Keyed-Verification 
+## MAC proposed by Chase, Meiklejohn and Zaverucha in Algebraic MACs and Keyed-Verification
 ## Anonymous Credentials", at ACM CCS 2014. The credentials scheme
 ## is based on the GGM based aMAC. (see section 4.2, pages 8-9)
 
@@ -55,7 +55,7 @@ def secret_proof(params, n):
 
 def cred_secret_issue_user(params, keypair, attrib):
     """ Encodes a number of secret attributes to be issued. """
-    
+
     # We simply encrypt all parameters and make a proof we know
     # the decryption.
     G, g, h, o = params
@@ -74,7 +74,7 @@ def cred_secret_issue_user(params, keypair, attrib):
     zk = secret_proof(params, len(attrib))
 
     ## Run the proof
-    env = ZKEnv(zk) 
+    env = ZKEnv(zk)
     env.g, env.h = g, h
     env.pub = pub
     env.priv = priv
@@ -107,7 +107,7 @@ def cred_secret_issue_user_check(params, pub, EGenc, sig):
     zk = secret_proof(params, len(Cis))
 
     ## Run the proof
-    env = ZKEnv(zk) 
+    env = ZKEnv(zk)
     env.g, env.h = g, h
     env.pub = pub
 
@@ -146,10 +146,10 @@ def cred_secret_issue_proof(params, num_privs, num_pubs):
 
     ## Proof of correct Xi's
     for (xi, Xi, bXi, bxi) in zip(xis, Xis, bXis, bxis):
-        zk.add_proof(Xi, xi * h)        
+        zk.add_proof(Xi, xi * h)
         zk.add_proof(bXi, b * Xi)
         zk.add_proof(bXi, bxi * h)
-    
+
     # Proof of correct Credential Ciphertext
     mis = zk.get_array(ConstPub, "mi", num_pubs)
     CredA, CredB = zk.get(ConstGen, ["CredA", "CredB"])
@@ -173,7 +173,7 @@ def cred_secret_issue_proof(params, num_privs, num_pubs):
     zk.add_proof(CredB, B)
 
     return zk
-    
+
 
 def cred_secret_issue(params, pub, EGenc, publics, secrets, messages):
     """ Encode a mixture of secret (EGenc) and public (messages) attributes"""
@@ -207,7 +207,7 @@ def cred_secret_issue(params, pub, EGenc, publics, secrets, messages):
     assert [bsk0] + open_bsk + sec_bsk == bsk
 
     # First build a proto-credential in clear using all public attribs
-    r_prime = o.random()    
+    r_prime = o.random()
     EG_a = r_prime * g
     EG_b = r_prime * pub + bsk0 * g
 
@@ -224,7 +224,7 @@ def cred_secret_issue(params, pub, EGenc, publics, secrets, messages):
     env = ZKEnv(zk)
 
     env.pub = pub
-    env.g, env.h = g, h 
+    env.g, env.h = g, h
     env.u = u
     env.b = b
 
@@ -235,7 +235,7 @@ def cred_secret_issue(params, pub, EGenc, publics, secrets, messages):
     env.bx_0_bar = b.mod_mul(x0_bar, o)
     env.Cx_0 = Cx0
     env.bCx_0 = bCx0
-    
+
     # These relate to the knowledge of Xi, xi ...
     env.xi = sk[1:]
     env.Xi = iparams
@@ -244,7 +244,7 @@ def cred_secret_issue(params, pub, EGenc, publics, secrets, messages):
 
     # These relate to the knowledge of the plaintext ...
     env.r_prime = r_prime
-    env.mi = messages   
+    env.mi = messages
     env.CredA = EG_a
     env.CredB = EG_b
     env.EGai = sKis
@@ -285,19 +285,19 @@ def cred_secret_issue_user_decrypt(params, keypair, u, EncE, publics, messages, 
 
     env = ZKEnv(zk)
 
-    env.g, env.h = g, h 
+    env.g, env.h = g, h
     env.u = u
     env.Cx_0 = Cx0
     env.pub = pub
 
-    env.Xi = iparams    
+    env.Xi = iparams
 
-    env.mi = messages   
+    env.mi = messages
     env.CredA = EG_a
     env.CredB = EG_b
     env.EGai = sKis
     env.EGbi = Cis
-    
+
     ## Extract the proof
     if not zk.verify_proof(env.get(), sig):
         raise Exception("Decryption of credential failed.")
@@ -322,7 +322,7 @@ def cred_issue_proof(params, n):
     ## Proof of correct MAC
     Prod = x0 * u
     for (xi, mi) in zip(xis, mis):
-        Prod = Prod + xi*(mi * u) 
+        Prod = Prod + xi*(mi * u)
     zk.add_proof(up, Prod)
 
     ## Proof of knowing the secret of MAC
@@ -330,7 +330,7 @@ def cred_issue_proof(params, n):
 
     ## Proof of correct Xi's
     for (xi, Xi) in zip(xis, Xis):
-        zk.add_proof(Xi, xi * h)        
+        zk.add_proof(Xi, xi * h)
 
     return zk
 
@@ -348,7 +348,7 @@ def cred_issue(params, publics, secrets, messages):
 
     env = ZKEnv(zk)
 
-    env.g, env.h = g, h 
+    env.g, env.h = g, h
     env.u, env.up = u, uprime
     env.x0 = sk[0]
     env.x0_bar = x0_bar
@@ -367,7 +367,7 @@ def cred_issue(params, publics, secrets, messages):
     return (u, uprime), sig
 
 def cred_issue_check(params, publics, mac, sig, messages):
-    
+
     # Parse public variables
     G, g, h, _ = params
     Cx0, iparams = publics
@@ -378,7 +378,7 @@ def cred_issue_check(params, publics, mac, sig, messages):
     zk = cred_issue_proof(params, n)
 
     env = ZKEnv(zk)
-    env.g, env.h = g, h 
+    env.g, env.h = g, h
     env.u, env.up = u, uprime
     env.Cx0 = Cx0
 
@@ -426,7 +426,7 @@ def cred_show(params, publics, mac, sig, messages, cred_show_proof=cred_show_pro
     u, uprime = rerandomize_sig_ggm(params, mac)
 
     n = len(messages)
-    
+
     ## Blinding variables for the proof
     r = o.random()
     zis = [o.random() for _ in range(n)]
@@ -506,18 +506,18 @@ def time_it_all(repetitions = 1000):
 
     print("Timings of operations (%s repetitions)" % repetitions)
 
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         i = 0
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tIdle" % (1000 * T/repetitions))
 
 
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         ## Setup from credential issuer.
         params = cred_setup()
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tCredential Group Setup" % (1000 * T/repetitions))
 
     G, _, _, o = params
@@ -527,25 +527,25 @@ def time_it_all(repetitions = 1000):
     private_attr = [o.random(), o.random()]
     n = len(public_attr) + len(private_attr)
 
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         ipub, isec = cred_CredKeyge(params, n)
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tCredential Key generation" % (1000 * T/repetitions))
 
     ## User generates keys and encrypts some secret attributes
     #  the secret attributes are [10, 20]
 
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         keypair = cred_UserKeyge(params)
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tUser Key generation" % (1000 * T/repetitions))
 
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         pub, EGenc, sig = cred_secret_issue_user(params, keypair, private_attr)
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tUser Key generation (proof)" % (1000 * T/repetitions))
 
     if __debug__:
@@ -553,44 +553,44 @@ def time_it_all(repetitions = 1000):
 
     ## The issuer checks the secret attributes and encrypts a amac
     #  It also includes some public attributes, namely [30, 40].
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         if not cred_secret_issue_user_check(params, pub, EGenc, sig):
             raise Exception("User key generation invalid")
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tUser Key generation (verification)" % (1000 * T/repetitions))
 
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         u, EncE, sig = cred_secret_issue(params, pub, EGenc, ipub, isec, public_attr)
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tCredential issuing" % (1000 * T/repetitions))
-    
+
     if __debug__:
         _internal_ckeck(keypair, u, EncE, isec, public_attr + private_attr)
 
     ## The user decrypts the amac
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         mac = cred_secret_issue_user_decrypt(params, keypair, u, EncE, ipub, public_attr, EGenc, sig)
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tCredential decryption & verification" % (1000 * T/repetitions))
-    
+
     ## The show protocol using the decrypted amac
-    #  The proof just proves knowledge of the attributes, but any other 
+    #  The proof just proves knowledge of the attributes, but any other
     #  ZK statement is also possible by augmenting the proof.
-    
-    t0 = time.clock()
+
+    t0 = time.process_time()
     for _ in range(repetitions):
         (creds, sig) = cred_show(params, ipub, mac, sig, public_attr + private_attr)
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tCredential Show (proof)" % (1000 * T/repetitions))
 
-    t0 = time.clock()
+    t0 = time.process_time()
     for _ in range(repetitions):
         if not cred_show_check(params, ipub, isec, creds, sig):
             raise Exception("Credential show failed.")
-    T = time.clock() - t0
+    T = time.process_time() - t0
     print("%.3f ms\tCredential Show (verification)" % (1000 * T/repetitions))
 
 
@@ -622,7 +622,7 @@ def test_creds_custom_show():
     assert cred_issue_check(params, ipub, mac, sig, [10, 20])
 
     ## Custom proofs require two things:
-    #   - cred_show_proof_custom: a custom "cred_show_proof" with additional statements 
+    #   - cred_show_proof_custom: a custom "cred_show_proof" with additional statements
     #     to prove on the Commitements Cmi = mi * u + zi * h
     #   - xenv: a custom function that instanciates the values of the proof, either
     #     public secret or constant.
@@ -632,13 +632,13 @@ def test_creds_custom_show():
         zk = cred_show_proof(params, n)
 
         u, g, h = zk.get(ConstGen, ["u", "g", "h"])
-    
+
         zis = zk.get_array(Sec, "zi", n)
         mis = zk.get_array(Sec, "mi", n)
-    
+
         Cmis = zk.get_array(ConstGen, "Cmi", n)
         twou = zk.get(ConstGen, "twou")
-        
+
         # Statement that proves Cmi1 = (2 * m0) * u + z1 * h
         zk.add_proof(Cmis[1], mis[0]*twou + zis[1]*h)
         return zk
@@ -668,7 +668,7 @@ def test_secret_creds():
     #  the secret attributes are [10, 20]
     keypair = cred_UserKeyge(params)
     pub, EGenc, sig = cred_secret_issue_user(params, keypair, private_attr)
-    
+
     if __debug__:
         _check_enc(params, keypair, EGenc, private_attr)
 
@@ -676,15 +676,15 @@ def test_secret_creds():
     #  It also includes some public attributes, namely [30, 40].
     assert cred_secret_issue_user_check(params, pub, EGenc, sig)
     u, EncE, sig = cred_secret_issue(params, pub, EGenc, ipub, isec, public_attr)
-    
+
     if __debug__:
         _internal_ckeck(keypair, u, EncE, isec, public_attr + private_attr)
 
     ## The user decrypts the amac
     mac = cred_secret_issue_user_decrypt(params, keypair, u, EncE, ipub, public_attr, EGenc, sig)
-    
+
     ## The show protocol using the decrypted amac
-    #  The proof just proves knowledge of the attributes, but any other 
+    #  The proof just proves knowledge of the attributes, but any other
     #  ZK statement is also possible by augmenting the proof.
     (creds, sig) = cred_show(params, ipub, mac, sig, public_attr + private_attr)
     assert cred_show_check(params, ipub, isec, creds, sig)
@@ -695,7 +695,7 @@ if __name__ == "__main__":
     time_it_all(repetitions=100)
 
     params = cred_setup()
-    
+
     print("Proof of secret attributes")
     zk1 = secret_proof(params, 2)
     print(zk1.render_proof_statement())

--- a/examples/tormedian.py
+++ b/examples/tormedian.py
@@ -22,7 +22,7 @@ def _make_table(start=-10000, end=10000):
         i_table[ix] = i
         n_table[(o + i) % o] = ix
         ix = ix + g
-        
+
     return i_table, n_table
 
 _table, _n_table = _make_table()
@@ -40,7 +40,7 @@ class Ct:
         g = pub.group.generator()
         a = k * g
         b = k * pub + _n_table[(o + m) % o] # m * g
-        return Ct(pub, a, b, k, m) 
+        return Ct(pub, a, b, k, m)
 
     def __init__(self, pub, a, b, k=None, m=None):
         """ Produce a ciphertext, from its parts """
@@ -112,18 +112,18 @@ class Ct:
     def __rmul__(self, other):
         """ Multiples an integer with a Ciphertext """
         o = self.pub.group.order()
-        new_a = other * self.a 
+        new_a = other * self.a
         new_b = other * self.b
         new_k, new_m = None, None
         if self.k is not None:
             new_k = self.k.mod_mul( other, o)
-            new_m = self.m.mod_mul( other, o) 
+            new_m = self.m.mod_mul( other, o)
         return Ct(self.pub, new_a, new_b, new_k, new_m)
 
     def __neg__(self):
         """ Multiply the value by -1 """
         o = self.pub.group.order()
-        new_a = -self.a 
+        new_a = -self.a
         new_b = -self.b
         if self.k is not None and self.m is not None:
             new_k = (o - self.k) % o
@@ -145,7 +145,7 @@ def hashes(item, d):
     codes = []
     i = 0
     while len(codes) < d:
-        codes += list(array('I', sha512(pack("I", i) + item.encode("utf8")).digest())) 
+        codes += list(array('I', sha512(pack("I", i) + item.encode("utf8")).digest()))
         i += 1
     return codes[:d]
 
@@ -189,13 +189,13 @@ class CountSketchCt(object):
                 ba = self.store[di][wi].a.export()
                 dst.write(pack("I", len(ba)))
                 dst.write(ba)
-                
+
                 bb = self.store[di][wi].b.export()
                 dst.write(pack("I", len(bb)))
                 dst.write(bb)
 
         return dst.getvalue()
-                
+
 
 
     def insert(self, item):
@@ -204,7 +204,7 @@ class CountSketchCt(object):
         item = str(item)
         h = hashes(item, self.d)
         for di in range(self.d):
-            self.store[di][h[di] % self.w] += 1 
+            self.store[di][h[di] % self.w] += 1
 
     def estimate(self, item):
         """ Estimate the frequency of one value """
@@ -221,10 +221,10 @@ class CountSketchCt(object):
 
         elist = []
         for i, [hi, hpi] in enumerate(zip(h, h2)):
-            v1 = self.store[i][hi % self.w] 
+            v1 = self.store[i][hi % self.w]
             v2 = self.store[i][hpi % self.w]
             elist += [v1, -v2]
-        
+
         estimates = Ct.sum(elist)
         return estimates, self.d
 
@@ -237,7 +237,7 @@ class CountSketchCt(object):
             for o in others:
                 assert pub == o.pub
                 assert w == o.w and d == o.d
-        
+
         cs = CountSketchCt(w, d, pub)
 
         for di in range(d):
@@ -267,9 +267,9 @@ def get_median(cs, min_b = 0, max_b = 1000, steps = 20):
 
         EL = Ct.sum([ cs.estimate(i)[0] for i in range(bounds[0], cand_median) ])
         newl = yield EL # EL.dec(sec)
-        
+
         if total is None:
-            ER = Ct.sum([ cs.estimate(i)[0] for i in range(cand_median, bounds[1]) ])        
+            ER = Ct.sum([ cs.estimate(i)[0] for i in range(cand_median, bounds[1]) ])
             newr = yield ER # ER.dec(sec)
 
             total = newl + newr
@@ -278,7 +278,7 @@ def get_median(cs, min_b = 0, max_b = 1000, steps = 20):
         else:
             newr = total - newl
             if __debug__:
-                ER = Ct.sum( [ cs.estimate(i)[0] for i in range(cand_median, bounds[1]) ])        
+                ER = Ct.sum( [ cs.estimate(i)[0] for i in range(cand_median, bounds[1]) ])
                 newrx = yield ER # ER.dec(sec)
                 # assert newrx == newr
 
@@ -293,7 +293,7 @@ def get_median(cs, min_b = 0, max_b = 1000, steps = 20):
 
         if bounds == old_bounds:
             yield cand_median
-            return 
+            return
 
 
 #### ------------- TESTS ------------------
@@ -334,7 +334,7 @@ def test_Decrypt():
         i = random.randint(-1000, 999)
         E = Ct.enc(y, i)
         assert E.dec(x) == i
-    
+
 
 
 def analyze_series(eps, datapoints):
@@ -358,7 +358,7 @@ def test_CountSketchCt():
     G = EcGroup()
     x = G.order().random()
     y = x * G.generator()
-    
+
     cs = CountSketchCt(50, 7, y)
     cs.insert(11)
     c, d = cs.estimate(11)
@@ -380,10 +380,10 @@ def size_vs_error():
     narrow_vals = 1000
     wide_vals = 200
 
-    from numpy.random import laplace    
+    from numpy.random import laplace
     from collections import defaultdict
 
-    
+
     datapoints = defaultdict(list)
     sizes = defaultdict(list)
 
@@ -420,7 +420,7 @@ def size_vs_error():
                 plain = v.dec(sec) + noise
 
             print("Estimated median: %s\t\tAbs. Err: %s" % (v, abs(v - median)))
-            datapoints[epsilon] += [ 100 * float(abs(v - median)) / median ] 
+            datapoints[epsilon] += [ 100 * float(abs(v - median)) / median ]
 
     lower_err, core_err, upper_err = analyze_series(eps, datapoints)
     lower_siz, core_siz, upper_siz = analyze_series(eps, sizes)
@@ -470,10 +470,10 @@ def no_test_DP_median():
     narrow_vals = 1000
     wide_vals = 200
 
-    from numpy.random import laplace    
+    from numpy.random import laplace
     from collections import defaultdict
 
-    
+
     datapoints = defaultdict(list)
 
     eps = ["Inf", 1, 0.5, 0.1, 0.05, 0.01, 0.005, 0.001]
@@ -511,7 +511,7 @@ def no_test_DP_median():
                 plain = v.dec(sec) + noise
 
             print("Estimated median: %s\t\tAbs. Err: %s" % (v, abs(v - median)))
-            datapoints[epsilon] += [ abs(v - median) ] 
+            datapoints[epsilon] += [ abs(v - median) ]
 
     import matplotlib.pyplot as plt
     from numpy import mean, std
@@ -563,7 +563,7 @@ def do_median(vals, err=0.05, vrange=[0, 1000], verbose=True):
     G = EcGroup()
     sec = G.order().random()
     y = sec * G.generator()
-    
+
 
     xx = CountSketchCt.epsilondelta(err, err, y)
     d, w = xx.d, xx.w
@@ -571,7 +571,7 @@ def do_median(vals, err=0.05, vrange=[0, 1000], verbose=True):
         print("Sketch: d=%s w=%s (Cmp. size: %s%%)" % (d, w, (float(100*d*w)/(vrange[1] - vrange[0]))))
 
     # Add each sample to the sketch
-    tic = time.clock()    
+    tic = time.process_time()
 
     all_cs = []
     for x in vals:
@@ -579,15 +579,15 @@ def do_median(vals, err=0.05, vrange=[0, 1000], verbose=True):
         cs_temp.insert("%s" % x)
         all_cs += [ cs_temp ]
 
-    toc = time.clock()
+    toc = time.process_time()
     if verbose:
         print("Build Sketches: %2.4f sec (for %s)\tPer Sketch: %2.4f sec" % ((toc - tic), len(vals), (toc - tic) / len(vals)) )
 
     # Aggregate all sketches
-    tic = time.clock()
+    tic = time.process_time()
     cs = CountSketchCt.aggregate(all_cs)
 
-    toc = time.clock()
+    toc = time.process_time()
     dt = (toc - tic)
     if verbose:
         print("Aggregate Sketches: %2.4f sec (for %s)\tPer Sketch: %2.4f sec" % (dt, len(vals), dt / len(vals)) )
@@ -595,7 +595,7 @@ def do_median(vals, err=0.05, vrange=[0, 1000], verbose=True):
     # Now use test the median function
     proto = get_median(cs, min_b = vrange[0], max_b = vrange[1], steps = 20)
 
-    tic = time.clock()
+    tic = time.process_time()
 
     plain = None
     no_decryptions = 0
@@ -606,14 +606,14 @@ def do_median(vals, err=0.05, vrange=[0, 1000], verbose=True):
         no_decryptions += 1
         plain = v.dec(sec)
 
-    toc = time.clock()
+    toc = time.process_time()
     if verbose:
         print( "Find Median. Pivot: % 5d\tNo. Decryptions: %s\ttime: %2.4f sec" % (v, no_decryptions, toc - tic) )
 
     # Measure the size of the sketch
     bin_cs = cs.dump()
     if verbose:
-        print("Sketch size: %s bytes" % len(bin_cs))    
+        print("Sketch size: %s bytes" % len(bin_cs))
         print("Estimated median: %s\t\tAbs. Err: %s" % (v, abs(v - median)))
     return v
 
@@ -623,7 +623,7 @@ def test_median():
     # Get some test data
     narrow_vals = 100
     wide_vals = 20
-    
+
     vals = [gauss(300, 25) for _ in range (narrow_vals)]
     vals += [gauss(500, 200) for _ in range (wide_vals)]
 
@@ -659,7 +659,7 @@ if __name__ == "__main__":
             try:
                 vals = sorted([float(f) for f in data.iloc[0:num, i]])
                 med_gt = vals[len(vals)/2]
-                
+
                 MX = 100
                 vmin = min(vals) - 10
                 vmax = max(vals) + 10
@@ -677,7 +677,7 @@ if __name__ == "__main__":
                 d += [(data.columns.values[i], [med1, err1* 100, med2, err2* 100, med_gt])]
 
             except:
-                pass 
+                pass
                 # print data.iloc[0:num, i]
 
         frame = pd.DataFrame.from_items(d, orient="index", columns=["Median (0.25)", "Error (%)", "Median (0.05)", "Error (%)", "Truth"])
@@ -688,7 +688,7 @@ if __name__ == "__main__":
 
     if args.size:
         size_vs_error()
-    
+
     if args.quality:
         no_test_DP_median()
 
@@ -696,7 +696,7 @@ if __name__ == "__main__":
     if args.cprof:
         import cProfile
         cProfile.run("test_median()", sort="tottime")
-        
+
 
     if args.lprof:
         from line_profiler import LineProfiler

--- a/petlib/ec.py
+++ b/petlib/ec.py
@@ -782,10 +782,10 @@ def test_p224_const_timing():
         o = Bn(2) ** x
         tests = [o.random() for _ in range(repreats)]
 
-        t0 = time.clock()
+        t0 = time.process_time()
         for y in tests:
             dud = y * h
-        t += [time.clock() - t0]
+        t += [time.process_time() - t0]
         print(x, t[-1] / repreats)
     assert abs(t[0] - t[-1]) < 5.0 / 100
 

--- a/petlib/ecdsa.py
+++ b/petlib/ecdsa.py
@@ -224,27 +224,27 @@ def test_ecdsa_timing():
     t = []
 
     x = "Sign. plain"
-    t0 = time.clock()
+    t0 = time.process_time()
     for y in range(repreats):
         sig = do_ecdsa_sign(G, sig_key, digest)
-    t += [time.clock() - t0]
+    t += [time.process_time() - t0]
 
     print("%s:\t%2.2f/sec" % (x, 1.0 / (float(t[-1]) / repreats)))
 
     x = "Sign. with setup"
-    t0 = time.clock()
+    t0 = time.process_time()
     kinv_rp = do_ecdsa_setup(G, sig_key)
     for y in range(repreats):
         sig = do_ecdsa_sign(G, sig_key, digest, kinv_rp=kinv_rp)
-    t += [time.clock() - t0]
+    t += [time.process_time() - t0]
 
     print("%s:\t%2.2f/sec" % (x, 1.0 / (float(t[-1]) / repreats)))
 
     x = "Verification"
-    t0 = time.clock()
+    t0 = time.process_time()
     kinv_rp = do_ecdsa_setup(G, sig_key)
     for y in range(repreats):
         do_ecdsa_verify(G, ver_key, sig, digest)
-    t += [time.clock() - t0]
+    t += [time.process_time() - t0]
 
     print("%s:\t%2.2f/sec" % (x, 1.0 / (float(t[-1]) / repreats)))


### PR DESCRIPTION
Hello,

Some tests fail because the method `time.clock()` was removed from Python 3.8.

I replaced the calls to this method by `time.process_time()` to measure the processing time. Additionally, `process_time()` should have an identical behavior across OSes.

Best regards,

Laurent Girod